### PR TITLE
Add ability to accept options hash

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,31 +3,28 @@ PATH
   specs:
     has_protected_token (0.0.0)
       activerecord (>= 3.0)
-      bcrypt (>= 3.0)
+      bcrypt (~> 3.1.1)
 
 GEM
   remote: https://rubygems.org/
   specs:
-    activemodel (4.2.11.1)
-      activesupport (= 4.2.11.1)
-      builder (~> 3.1)
-    activerecord (4.2.11.1)
-      activemodel (= 4.2.11.1)
-      activesupport (= 4.2.11.1)
-      arel (~> 6.0)
-    activesupport (4.2.11.1)
-      i18n (~> 0.7)
+    activemodel (6.0.0)
+      activesupport (= 6.0.0)
+    activerecord (6.0.0)
+      activemodel (= 6.0.0)
+      activesupport (= 6.0.0)
+    activesupport (6.0.0)
+      concurrent-ruby (~> 1.0, >= 1.0.2)
+      i18n (>= 0.7, < 2)
       minitest (~> 5.1)
-      thread_safe (~> 0.3, >= 0.3.4)
       tzinfo (~> 1.1)
-    arel (6.0.4)
+      zeitwerk (~> 2.1, >= 2.1.8)
     bcrypt (3.1.13)
-    builder (3.2.3)
     byebug (11.0.1)
     concurrent-ruby (1.1.5)
     database_cleaner (1.7.0)
     diff-lcs (1.3)
-    i18n (0.9.5)
+    i18n (1.7.0)
       concurrent-ruby (~> 1.0)
     minitest (5.12.2)
     rake (13.0.0)
@@ -44,10 +41,11 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.8.0)
     rspec-support (3.8.3)
-    sqlite3 (1.3.13)
+    sqlite3 (1.4.1)
     thread_safe (0.3.6)
     tzinfo (1.2.5)
       thread_safe (~> 0.1)
+    zeitwerk (2.2.0)
 
 PLATFORMS
   ruby
@@ -59,7 +57,7 @@ DEPENDENCIES
   has_protected_token!
   rake
   rspec
-  sqlite3 (~> 1.3.13)
+  sqlite3
 
 BUNDLED WITH
    1.17.3

--- a/has_protected_token.gemspec
+++ b/has_protected_token.gemspec
@@ -11,12 +11,12 @@ Gem::Specification.new do |s|
   s.license     = 'MIT'
 
   s.add_dependency 'activerecord', '>= 3.0'
-  s.add_dependency 'bcrypt', '>= 3.0'
+  s.add_dependency 'bcrypt', '~> 3.1.1'
 
   s.add_development_dependency 'bundler', '~> 1.17.3'
   s.add_development_dependency 'rake'
   s.add_development_dependency 'rspec'
-  s.add_development_dependency 'sqlite3', '~> 1.3.13'
+  s.add_development_dependency 'sqlite3'
   s.add_development_dependency 'byebug'
   s.add_development_dependency 'database_cleaner'
 end

--- a/spec/support/model.rb
+++ b/spec/support/model.rb
@@ -5,5 +5,9 @@ class User < Model
 end
 
 class SpecialUser < Model
-  has_protected_token :shared_secret
+  has_protected_token column_name: :shared_secret
+end
+
+class CostedUser < Model
+  has_protected_token cost: 9
 end


### PR DESCRIPTION
This required settling BCrypt dependency on ~> 3.1.1 in order to appropriately deal with the cost option